### PR TITLE
fix: PHP Warning: SimpleXMLElement::__construct()

### DIFF
--- a/src/SmartEmailing.php
+++ b/src/SmartEmailing.php
@@ -236,21 +236,32 @@ class SmartEmailing extends \Nette\Object
 
 
 	protected function callSmartemailingApiWithCurl($data) {
-		$ch = curl_init();
+		try {
+			$ch = curl_init();
 
-		curl_setopt($ch, CURLOPT_URL, $this->url);
-		curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
-		curl_setopt($ch, CURLOPT_HEADER, FALSE);
-		curl_setopt($ch, CURLOPT_POST, TRUE);
+			curl_setopt($ch, CURLOPT_URL, $this->url);
+			curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
+			curl_setopt($ch, CURLOPT_HEADER, FALSE);
+			curl_setopt($ch, CURLOPT_POST, TRUE);
 
-		$postFields = $this->createSimpleXml($data, 'xmlrequest');
+			$postFields = $this->createSimpleXml($data, 'xmlrequest');
 
-		curl_setopt($ch, CURLOPT_POSTFIELDS, $postFields);
-		curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/xml'));
+			curl_setopt($ch, CURLOPT_POSTFIELDS, $postFields);
+			curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/xml'));
 
-		$response = curl_exec($ch);
+			$response = curl_exec($ch);
 
-		curl_close($ch);
+			curl_close($ch);
+
+		} catch (\Exception $e) {
+			$xml = new \SimpleXMLElement('<response></response>');
+			$errorData = ['code' => $e->getCode(), 'message' => $e->getMessage()];
+
+			$this->arrayToXml($errorData, $xml);
+			
+			return $xml;
+		}
+
 
 		return new \SimpleXMLElement($response);
 	}

--- a/src/SmartEmailing.php
+++ b/src/SmartEmailing.php
@@ -19,8 +19,9 @@ class SmartEmailing extends \Nette\Object
 
 	/**
 	 * SmartEmailing constructor.
-	 * @param $username
-	 * @param $token
+	 *
+	 * @param string $username
+	 * @param string $token
 	 */
 	public function __construct($username, $token)
 	{
@@ -31,8 +32,8 @@ class SmartEmailing extends \Nette\Object
 
 	/**
 	 * insert contact to Smartemailing
-	 * 
-	 * @param $email
+	 *
+	 * @param string $email
 	 * @param array $contactlists
 	 * @param array $properties
 	 * @param array $customfields
@@ -46,7 +47,7 @@ class SmartEmailing extends \Nette\Object
 	/**
 	 * update contact in Smartemailing
 	 *
-	 * @param $email
+	 * @param string $email
 	 * @param array $contactlists
 	 * @param array $properties
 	 * @param array $customfields
@@ -93,7 +94,7 @@ class SmartEmailing extends \Nette\Object
 	/**
 	 * get Smartemailing contact by email address
 	 *
-	 * @param  String $email
+	 * @param string $email
 	 *
 	 * @return \SimpleXMLElement
 	 */
@@ -117,7 +118,7 @@ class SmartEmailing extends \Nette\Object
 	/**
 	 * get Smartemailing contact by ID
 	 *
-	 * @param  int $id
+	 * @param int $id
 	 *
 	 * @return [ty\SimpleXMLElement
 	 */
@@ -141,7 +142,7 @@ class SmartEmailing extends \Nette\Object
 	/**
 	 * delete Smartemailing contact by email address
 	 *
-	 * @param  String $email
+	 * @param string $email
 	 *
 	 * @return \SimpleXMLElement
 	 */
@@ -225,7 +226,7 @@ class SmartEmailing extends \Nette\Object
 	/**
 	 * convert array to xml
 	 *
-	 * @param $array
+	 * @param array $array
 	 * @param $xml
 	 */
 	protected function arrayToXml($array, &$xml) {
@@ -251,8 +252,8 @@ class SmartEmailing extends \Nette\Object
 	/**
 	 * creating simple xml
 	 *
-	 * @param $array
-	 * @param $rootElementName
+	 * @param array $array
+	 * @param string $rootElementName
 	 * @return mixed
 	 */
 	protected function createSimpleXml($array, $rootElementName) {
@@ -267,7 +268,7 @@ class SmartEmailing extends \Nette\Object
 	/**
 	 * connect to Smartemailing API v2
 	 *
-	 * @param $data
+	 * @param array $data
 	 * @return \SimpleXMLElement
 	 */
 	protected function callSmartemailingApiWithCurl($data) {
@@ -305,8 +306,8 @@ class SmartEmailing extends \Nette\Object
 	/**
 	 * return error XML
 	 *
-	 * @param $code
-	 * @param $message
+	 * @param string $code
+	 * @param string $message
 	 * @return \SimpleXMLElement
 	 */
 	public function getErrorXml($code, $message) {
@@ -322,7 +323,7 @@ class SmartEmailing extends \Nette\Object
 	/**
 	 * check if xml string is valid
 	 *
-	 * @param $xmlString
+	 * @param string $xmlString
 	 * @return bool
 	 */
 	protected function isValidXmlString($xmlString) {

--- a/src/SmartEmailing.php
+++ b/src/SmartEmailing.php
@@ -227,7 +227,7 @@ class SmartEmailing extends \Nette\Object
 	 * convert array to xml
 	 *
 	 * @param array $array
-	 * @param $xml
+	 * @param \SimpleXMLElement $xml
 	 */
 	protected function arrayToXml($array, &$xml) {
 		foreach($array as $key => $value) {

--- a/src/SmartEmailing.php
+++ b/src/SmartEmailing.php
@@ -254,7 +254,7 @@ class SmartEmailing extends \Nette\Object
 	 *
 	 * @param array $array
 	 * @param string $rootElementName
-	 * @return mixed
+	 * @return string | bool ... string on success and FALSE on error
 	 */
 	protected function createSimpleXml($array, $rootElementName) {
 		$xml = new \SimpleXMLElement('<' . $rootElementName . '></' . $rootElementName . '>');


### PR DESCRIPTION
- pripojenie do Smartemailing API obalene do try-catch
- doplnene komentare k funkciam
- pridana funkcia isValidXmlString, ktora kontroluje ci je xml response od Smartemailingu validny
- pridana funkcia getErrorXml, ktora vrati xml s chybou