### PR TITLE
zrusena funkcia isValidXmlString($xmlString)

### DIFF
--- a/src/SmartEmailing.php
+++ b/src/SmartEmailing.php
@@ -293,10 +293,10 @@ class SmartEmailing extends \Nette\Object
 			return $this->getErrorXml($e->getCode(), $e->getMessage());
 		}
 
+		$xml = simplexml_load_string($response);
 
-		if ($this->isValidXmlString($response)) {
-			return new \SimpleXMLElement($response);
-
+		if ($xml) {
+			return $xml;
 		} else {
 			return $this->getErrorXml('500', 'Unknown Smartemailing API error.');
 		}
@@ -317,27 +317,6 @@ class SmartEmailing extends \Nette\Object
 		$this->arrayToXml($errorData, $xml);
 
 		return $xml;
-	}
-
-
-	/**
-	 * check if xml string is valid
-	 *
-	 * @param string $xmlString
-	 * @return bool
-	 */
-	protected function isValidXmlString($xmlString) {
-		libxml_use_internal_errors(TRUE);
-
-		$doc = simplexml_load_string($xmlString);
-
-		if (!$doc) {
-			$errors = libxml_get_errors();
-
-			return empty($errors);
-		}
-
-		return FALSE;
 	}
 
 }

--- a/src/SmartEmailing.php
+++ b/src/SmartEmailing.php
@@ -295,7 +295,7 @@ class SmartEmailing extends \Nette\Object
 
 		$xml = simplexml_load_string($response);
 
-		if ($xml) {
+		if ($xml !== FALSE) {
 			return $xml;
 		} else {
 			return $this->getErrorXml('500', 'Unknown Smartemailing API error.');


### PR DESCRIPTION
- ta funkcia isValidXmlString($xmlString) nespravne vracala FALSE aj ked bol string validne XML ... uplne som ju zrusil
- uz funkcia simplexml_load_string() vracia objekt SimpleXMLElement ak je string validne XML alebo FALSE ak nie je